### PR TITLE
Add PositionAwareToken protocol

### DIFF
--- a/Sources/CornerParser/Lexer/LexedToken.swift
+++ b/Sources/CornerParser/Lexer/LexedToken.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-struct LexedToken: Equatable {
+struct LexedToken: PositionAwareToken, Equatable {
     let token: Token
     let position: Token.Position
+    
+    var line: Int { position.line }
+    var column: Int { position.column }
+    var symbol: String { token.symbol }
 }

--- a/Sources/CornerParser/Lexer/PositionAwareToken.swift
+++ b/Sources/CornerParser/Lexer/PositionAwareToken.swift
@@ -1,0 +1,12 @@
+//
+//  PositionAwareToken.swift
+//
+//
+//  Created by Mori Ahmadi on 2024-09-08.
+//
+
+public protocol PositionAwareToken {
+    var line: Int { get }
+    var column: Int { get }
+    var symbol: String { get }
+}

--- a/Sources/CornerParser/Lexer/Token.swift
+++ b/Sources/CornerParser/Lexer/Token.swift
@@ -24,4 +24,19 @@ enum Token: Equatable {
         var line: Int
         var column: Int
     }
+    
+    var symbol: String {
+        switch self {
+        case .node: return "node"
+        case .calls: return "calls"
+        case .identifier: return "Identifier"
+        case .lbrace: return "lbrace '{'"
+        case .rbrace: return "rbrace '}'"
+        case .colon: return ":"
+        case .color: return "color"
+        case .label: return "label"
+        case .quote: return "\""
+        default: return ""
+        }
+    }
 }

--- a/Sources/CornerParser/Parser/Parser.swift
+++ b/Sources/CornerParser/Parser/Parser.swift
@@ -55,7 +55,7 @@ class Parser {
             case .node:
                 elements.append(.node(try parseNode()))
             default:
-                throw ParseError.unexpectedToken(expected: .node, found: currentToken)
+                throw ParseError.unexpectedToken(expected: Token.node.symbol, found: currentToken)
             }
         }
         
@@ -70,7 +70,7 @@ class Parser {
         if currentToken.token == expectedToken {
             advance()
         } else {
-            throw ParseError.unexpectedToken(expected: expectedToken, found: currentToken)
+            throw ParseError.unexpectedToken(expected: expectedToken.symbol, found: currentToken)
         }
     }
     
@@ -92,7 +92,7 @@ class Parser {
             case .calls:
                 edges.append(try parseEdge(for: id))
             default:
-                throw ParseError.unexpectedToken(expected: .rbrace, found: currentToken)
+                throw ParseError.unexpectedToken(expected: Token.rbrace.symbol, found: currentToken)
             }
         }
         
@@ -117,7 +117,7 @@ class Parser {
             case .label:
                 attributes.append(try parseLabelAttribute())
             default:
-                throw ParseError.unexpectedToken(expected: .rbrace, found: currentToken)
+                throw ParseError.unexpectedToken(expected: Token.rbrace.symbol, found: currentToken)
             }
         }
         

--- a/Sources/CornerParser/Parser/ParserError.swift
+++ b/Sources/CornerParser/Parser/ParserError.swift
@@ -7,16 +7,32 @@
 
 import Foundation
 
-enum ParseError: Error, CustomStringConvertible, Equatable {
-    case unexpectedToken(expected: Token, found: LexedToken)
+public enum ParseError: Error, CustomStringConvertible {
+    case unexpectedToken(expected: String, found: any PositionAwareToken)
     case expectedIdentifier
     
-    var description: String {
+    public var description: String {
         switch self {
         case let .unexpectedToken(expected, found):
-            return "Unexpected token at line: \(found.position.line). Expected \(expected), found \(found.token)"
+            return "Unexpected token at line: \(found.line). Expected \(expected), found \(found.symbol)"
         case .expectedIdentifier:
             return "Expected identifier"
+        }
+    }
+}
+
+extension ParseError: Equatable {
+    public static func == (lhs: ParseError, rhs: ParseError) -> Bool {
+        switch (lhs, rhs) {
+        case let (.unexpectedToken(expected1, found1), .unexpectedToken(expected2, found2)):
+            return expected1 == expected2
+            && found1.line == found2.line
+            && found1.column == found2.column
+            && found1.column == found2.column
+        case (.expectedIdentifier, .expectedIdentifier):
+            return true
+        default:
+            return false
         }
     }
 }

--- a/Tests/CornerParserTests/ParserTests.swift
+++ b/Tests/CornerParserTests/ParserTests.swift
@@ -221,7 +221,7 @@ final class ParserTests: XCTestCase {
             XCTAssertEqual(
                 error as? ParseError,
                 .unexpectedToken(
-                    expected: .lbrace,
+                    expected: Token.lbrace.symbol,
                     found: LexedToken(
                         token: .colon,
                         position: .init(


### PR DESCRIPTION
In order to expose `ParserError` to outside without making `LexedToken` or `Token` public, I used `PositionAwareToken` to hold info from `LexedToken` 